### PR TITLE
Fix build/publish actions

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -9,12 +9,12 @@ env:
 jobs:
   build-container:
     name: Build and Publish Image
-    if: github.repository_owner == 'mborgerson'
+    if: github.repository_owner == 'xemu-project'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Clone Tree
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -25,10 +25,10 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         with:
           registry: ${{ env.REGISTRY }}
@@ -36,7 +36,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
@@ -52,7 +52,7 @@ jobs:
           python-version: '3.9'
 
       - name: Clone Tree
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 


### PR DESCRIPTION
Looks like none of the actions triggered with the last merge, presumably because of the change to the `xemu-project` org.

Is the owner filter still needed?